### PR TITLE
Fix feature overlap

### DIFF
--- a/src/components/info/feature-collection.vue
+++ b/src/components/info/feature-collection.vue
@@ -25,7 +25,7 @@
                     v-for="(key, index) in section.keys"
                     :key="key + index"
                 >
-                    <h2 class="!mt-0 md:h-[60px] lg:h-[80px] xl:h-[60px]">
+                    <h2 class="!mt-0 min-h-[100px]">
                         {{ $t(`feature.${key}.title`) }}
                     </h2>
                     <description-block


### PR DESCRIPTION
#58 

Feature titles will no longer overlap the description when in French

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp-website/60)
<!-- Reviewable:end -->
